### PR TITLE
Add explanations for global vs local alignment workflows

### DIFF
--- a/examples/02_scoring.ipynb
+++ b/examples/02_scoring.ipynb
@@ -132,7 +132,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `MoleculePair` class facilitates easy scoring between two conformations as well as alignment. Note that by setting `do_center=True` we align the center of mass's to the origin which would not be desireable if we wanted to do a local relaxation."
+    "The `MoleculePair` class facilitates easy scoring between two conformations as well as alignment. Note that by setting `do_center=True` we align each molecule's center of mass to the origin which would not be desirable if we wanted to do a local relaxation."
    ]
   },
   {
@@ -189,7 +189,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Alignment"
+    "#### Global Alignment\n",
+    "Global alignment assumes that we don't care about the initial alignment as we want to try to find the global minima. We previously aligned the COM's at the origin during the initialization of `MoleculePair`. The alignment methods, `.align_with_*`, all take the argument `num_repeats` which is the number of different initial alignments to optimize over. When `num_repeats > 1`, there are 3 main types of initializations: \n",
+    "\n",
+    "1. The first initialization maintains the rotational orientations of both molecules, but aligns the fit molecule's COM is moved to the reference molecule's COM.\n",
+    "2. The next four initializations align the molecules by their principal components.\n",
+    "3. If `num_repeats > 5`, the remaining initializations are uniformly spaced rotations of the fit molecule.\n",
+    "\n",
+    "The default `num_repeats=50`. Examples are shown below:"
    ]
   },
   {
@@ -276,6 +283,59 @@
     "transformed_fit_molec = mp.get_transformed_molecule(\n",
     "    se3_transform=mp.transform_surf\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Global alignment with translation initializations\n",
+    "The above code is generally sufficient for aligning molecules of the same relative size. However, sometimes we may want to be more thorough about the global search and/or we may be aligning a smaller molecule to a larger one. In the latter case, starting with aligned COM's may be insufficient for finding the best possible alignment.\n",
+    "\n",
+    "Therefore, each alignment method also contains an argument called `trans_init`. If set to `True`, the COM of the fit molecule will be shifted to each heavy atom of the reference molecule (in addition to principal component alignment). 10 uniform rotations are then sampled leading to `(5 + 10*num_ref_heavy_atoms)` different initializations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "surf_points_aligned_trans = mp.align_with_surf(ALPHA(mp.num_surf_points),\n",
+    "                                               num_repeats=50,\n",
+    "                                               trans_init=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Local Alignment\n",
+    "\n",
+    "In some cases, only local optimization is necessary. For example, if you have two overlayed molecules and you want to refine the alignment. To do so there are two important points:\n",
+    "1. Initialize `MoleculePair` with `do_center=False` so that the supplied conformers are not automatically aligned by their COM's.\n",
+    "2. Ensure that `mp.align_*(num_repeats=1)` so that the optimization procedure is initialized for the original alignment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mp = MoleculePair(ref_molec, fit_molec, num_surf_points=200, do_center=False)\n",
+    "surf_points_aligned_trans = mp.align_with_surf(ALPHA(mp.num_surf_points),\n",
+    "                                               num_repeats=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Additional notes\n",
+    "- If your molecular system is not near the origin, it is possible that the default step size or learning rate (default `lr=0.1`) is too large and can lead to catostrophic optimization updates. The reason for this is that the updates to rotation matrices are applied with respect to the global frame rather than a local one. To solve this, you can either:\n",
+    "    1. Reduce the learning rate.\n",
+    "    2. Center your entire (combined) system to the origin."
    ]
   },
   {


### PR DESCRIPTION
Added to `examples/02_scoring.ipynb`