### PR TITLE
Update jax pharmacophore scoring

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shepherd-score"
-version = "1.1.1"
+version = "1.1.2"
 description = "3D scoring functions used for evaluation of ShEPhERD"
 readme = "README.md"
 requires-python = ">=3.8,<3.12"

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ REQUIREMENTS = [
 
 setup(
     name="shepherd_score",
-    version="1.1.1",
+    version="1.1.2",
     packages=find_packages(),
     install_requires=REQUIREMENTS,  # Add your dependencies here
     author="Kento Abeywardane",

--- a/shepherd_score/alignment.py
+++ b/shepherd_score/alignment.py
@@ -365,7 +365,7 @@ def optimize_ROCS_overlay(ref_points: torch.Tensor,
 
     # Optimization loop
     if verbose:
-        print(f'Initial shape similarity score: {get_overlap(ref_points, fit_points, alpha):.3}')
+        print(f'Initial shape similarity score: {get_overlap(ref_points, fit_points, alpha):.3f}')
     last_loss = 1
     counter = 0
     # ref_points will be broadcast by the objective/scoring function
@@ -406,13 +406,13 @@ def optimize_ROCS_overlay(ref_points: torch.Tensor,
                          alpha=alpha)
     if num_repeats == 1:
         if verbose:
-            print(f'Optimized shape similarity score: {scores:.3}')
+            print(f'Optimized shape similarity score: {scores:.3f}')
         best_alignment = aligned_points.cpu()
         best_transform = SE3_transform.cpu()
         best_score = scores.cpu()
     else:
         if verbose:
-            print(f'Optimized shape similarity score -- max: {scores.max():3} | mean: {scores.mean():.3} | min: {scores.min():3}')
+            print(f'Optimized shape similarity score -- max: {scores.max():.3f} | mean: {scores.mean():.3f} | min: {scores.min():.3f}')
         best_idx = torch.argmax(scores.detach().cpu())
         best_alignment = aligned_points.cpu()[best_idx]
         best_transform = SE3_transform.cpu()[best_idx]
@@ -559,7 +559,7 @@ def optimize_ROCS_esp_overlay(ref_points: torch.Tensor,
 
     # Optimization loop
     if verbose:
-        print(f'Initial ESP similarity score: {get_overlap_esp(ref_points, fit_points, ref_charges, fit_charges, alpha, lam):.3}')
+        print(f'Initial ESP similarity score: {get_overlap_esp(ref_points, fit_points, ref_charges, fit_charges, alpha, lam):.3f}')
     
     last_loss = torch.tensor(float('inf'), device=ref_points.device) # Initialize with a high value
     counter = 0
@@ -618,14 +618,14 @@ def optimize_ROCS_esp_overlay(ref_points: torch.Tensor,
     
     if current_num_repeats == 1:
         if verbose:
-            print(f'Optimized ESP similarity score: {scores.item():.3}')
+            print(f'Optimized ESP similarity score: {scores.item():.3f}')
         best_alignment = aligned_points.cpu()
         best_transform = SE3_transform.cpu()
         best_score = scores.cpu()
     else:
         best_idx = torch.argmax(scores.detach().cpu())
         if verbose:
-            print(f'Optimized ESP similarity score -- max: {scores[best_idx].item():.3} | mean: {scores.mean().item():.3} | min: {scores.min().item():.3}')
+            print(f'Optimized ESP similarity score -- max: {scores[best_idx].item():.3f} | mean: {scores.mean().item():.3f} | min: {scores.min().item():.3f}')
         best_alignment = aligned_points.cpu()[best_idx]
         best_transform = SE3_transform.cpu()[best_idx]
         best_score = scores.cpu()[best_idx]
@@ -749,7 +749,7 @@ def optimize_esp_combo_score_overlay(ref_centers_w_H: torch.Tensor,
             probe_radius=probe_radius,
             esp_weight=esp_weight
         )
-        print(f'Initial ESP-combo score: {init_score.item():.3}')
+        print(f'Initial ESP-combo score: {init_score.item():.3f}')
     
     last_loss = torch.tensor(float('inf'), device=ref_points.device)
     counter = 0
@@ -835,14 +835,14 @@ def optimize_esp_combo_score_overlay(ref_centers_w_H: torch.Tensor,
 
     if current_num_repeats == 1:
         if verbose:
-            print(f'Optimized ESP-combo score: {scores.item():.3}')
+            print(f'Optimized ESP-combo score: {scores.item():.3f}')
         best_alignment = aligned_fit_points.cpu() # Consistent: return aligned surface points
         best_transform = SE3_transform.cpu()
         best_score = scores.cpu()
     else:
         best_idx = torch.argmax(scores.detach().cpu())
         if verbose:
-            print(f'Optimized ESP-combo score -- max: {scores[best_idx].item():.3} | mean: {scores.mean().item():.3} | min: {scores.min().item():.3}')
+            print(f'Optimized ESP-combo score -- max: {scores[best_idx].item():.3f} | mean: {scores.mean().item():.3f} | min: {scores.min().item():.3f}')
         best_alignment = aligned_fit_points.cpu()[best_idx]
         best_transform = SE3_transform.cpu()[best_idx]
         best_score = scores.cpu()[best_idx]
@@ -1036,7 +1036,7 @@ def optimize_pharm_overlay(ref_pharms: torch.Tensor,
             extended_points=extended_points,
             only_extended=only_extended
         )
-        print(f'Initial pharmacophore similarity score: {init_score:.3}')
+        print(f'Initial pharmacophore similarity score: {init_score:.3f}')
     last_loss = 1
     counter = 0
     ref_pharms_rep = ref_pharms.repeat((num_repeats,1)).squeeze(0)
@@ -1095,14 +1095,14 @@ def optimize_pharm_overlay(ref_pharms: torch.Tensor,
     )
     if num_repeats == 1:
         if verbose:
-            print(f'Optimized pharmacophore similarity score: {scores:.3}')
+            print(f'Optimized pharmacophore similarity score: {scores:.3f}')
         best_alignment = aligned_anchors.cpu()
         best_aligned_vectors = aligned_vectors.cpu()
         best_transform = SE3_transform.cpu()
         best_score = scores.cpu()
     else:
         if verbose:
-            print(f'Optimized pharmacophore similarity score -- max: {scores.max():3} | mean: {scores.mean():.3} | min: {scores.min():3}')
+            print(f'Optimized pharmacophore similarity score -- max: {scores.max():.3f} | mean: {scores.mean():.3f} | min: {scores.min():.3f}')
         best_idx = torch.argmax(scores.detach().cpu())
         best_alignment = aligned_anchors.cpu()[best_idx]
         best_aligned_vectors = aligned_vectors.cpu()[best_idx]

--- a/shepherd_score/alignment_jax.py
+++ b/shepherd_score/alignment_jax.py
@@ -450,7 +450,7 @@ def optimize_ROCS_overlay_jax(ref_points: Array,
 
     # Optimization loop
     if verbose:
-        print(f'Initial shape similarity score: {get_overlap_jax(ref_points, fit_points, alpha):.3}')
+        print(f'Initial shape similarity score: {get_overlap_jax(ref_points, fit_points, alpha):.3f}')
     last_loss = 1
     counter = 0
     for step in range(max_num_steps):
@@ -476,13 +476,13 @@ def optimize_ROCS_overlay_jax(ref_points: Array,
                                   alpha)
     if num_repeats == 1:
         if verbose:
-            print(f'Optimized shape similarity score: {scores:.3}')
+            print(f'Optimized shape similarity score: {scores:.3f}')
         best_alignment = aligned_points
         best_transform = SE3_transform
         best_score = scores
     else:
         if verbose:
-            print(f'Optimized shape similarity score -- max: {scores.max():3} | mean: {scores.mean():.3} | min: {scores.min():3}')
+            print(f'Optimized shape similarity score -- max: {scores.max():3f} | mean: {scores.mean():.3f} | min: {scores.min():3f}')
         best_idx = jnp.argmax(scores)
         best_alignment = aligned_points.at[best_idx].get()
         best_transform = SE3_transform.at[best_idx].get()
@@ -652,7 +652,7 @@ def optimize_ROCS_esp_overlay_jax(ref_points: Array,
 
     # Optimization loop
     if verbose:
-        print(f'Initial shape similarity score: {get_overlap_esp_jax(ref_points, fit_points, ref_charges, fit_charges, alpha, lam):.3}')
+        print(f'Initial shape similarity score: {get_overlap_esp_jax(ref_points, fit_points, ref_charges, fit_charges, alpha, lam):.3f}')
     last_loss = 1
     counter = 0
     for step in range(max_num_steps):
@@ -680,13 +680,13 @@ def optimize_ROCS_esp_overlay_jax(ref_points: Array,
                                       lam)
     if num_repeats == 1:
         if verbose:
-            print(f'Optimized shape+ESP similarity score: {scores:.3}')
+            print(f'Optimized shape+ESP similarity score: {scores:.3f}')
         best_alignment = aligned_points
         best_transform = SE3_transform
         best_score = scores
     else:
         if verbose:
-            print(f'Optimized shape+ESP similarity score -- max: {scores.max():3} | mean: {scores.mean():.3} | min: {scores.min():3}')
+            print(f'Optimized shape+ESP similarity score -- max: {scores.max():3f} | mean: {scores.mean():.3f} | min: {scores.min():3f}')
         best_idx = jnp.argmax(scores)
         best_alignment = aligned_points.at[best_idx].get()
         best_transform = SE3_transform.at[best_idx].get()
@@ -955,7 +955,7 @@ def optimize_esp_combo_score_overlay_jax(ref_centers_w_H: Union[Array, np.ndarra
                                          lam,
                                          probe_radius,
                                          esp_weight)
-        print(f'Initial ShaEP-inspired similarity score: {init_score:.3}')
+        print(f'Initial ShaEP-inspired similarity score: {init_score:.3f}')
     last_loss = 1
     counter = 0
     for step in range(max_num_steps):
@@ -1011,13 +1011,13 @@ def optimize_esp_combo_score_overlay_jax(ref_centers_w_H: Union[Array, np.ndarra
                                   esp_weight)
     if num_repeats == 1:
         if verbose:
-            print(f'Optimized ShaEP inspired similarity score: {scores:.3}')
+            print(f'Optimized ShaEP inspired similarity score: {scores:.3f}')
         best_alignment = aligned_points
         best_transform = SE3_transform
         best_score = scores
     else:
         if verbose:
-            print(f'Optimized ShaEP inspired similarity score -- max: {scores.max():3} | mean: {scores.mean():.3} | min: {scores.min():3}')
+            print(f'Optimized ShaEP inspired similarity score -- max: {scores.max():3f} | mean: {scores.mean():.3f} | min: {scores.min():3f}')
         best_idx = jnp.argmax(scores)
         best_alignment = aligned_points.at[best_idx].get()
         best_transform = SE3_transform.at[best_idx].get()
@@ -1128,7 +1128,7 @@ def optimize_pharm_overlay_jax(ref_pharms: Array,
 
     if verbose:
         init_score = get_overlap_pharm_jax(ref_pharms, fit_pharms, ref_anchors, fit_anchors, ref_vectors, fit_vectors, similarity, extended_points, only_extended)
-        print(f'Initial pharmacophore similarity score: {init_score:.3}')
+        print(f'Initial pharmacophore similarity score: {init_score:.3f}')
     
     last_loss = 1
     counter = 0
@@ -1156,14 +1156,14 @@ def optimize_pharm_overlay_jax(ref_pharms: Array,
 
     if current_num_repeats == 1:
         if verbose:
-            print(f'Optimized pharmacophore similarity score: {scores.squeeze():.3}')
+            print(f'Optimized pharmacophore similarity score: {scores.squeeze():.3f}')
         best_alignment = aligned_anchors.squeeze()
         best_aligned_vectors = aligned_vectors.squeeze()
         best_transform = SE3_transform.squeeze()
         best_score = scores.squeeze()
     else:
         if verbose:
-            print(f'Optimized pharmacophore similarity score -- max: {scores.max():.3} | mean: {scores.mean():.3} | min: {scores.min():.3}')
+            print(f'Optimized pharmacophore similarity score -- max: {scores.max():.3f} | mean: {scores.mean():.3f} | min: {scores.min():.3f}')
         best_idx = jnp.argmax(scores)
         best_alignment = aligned_anchors[best_idx]
         best_aligned_vectors = aligned_vectors[best_idx]

--- a/shepherd_score/score/gaussian_overlap_jax.py
+++ b/shepherd_score/score/gaussian_overlap_jax.py
@@ -167,17 +167,14 @@ def _VAB_2nd_order_cosine_jax_mask(centers_1: Array,
                                    ) -> Array:
     """
     2nd order volume overlap of AB weighted by cosine similarity (JAX version) - implementation part.
+    Vectors are assumed to be normalized.
     """
     R2 = jax_sq_cdist(centers_1, centers_2)  # (N1, N2)
     M2 = _mask_prod_jax(mask_1, mask_2)
     term_common = (jnp.pi**1.5) / ((2 * alpha)**1.5)
 
-    # Normalize vectors
-    vec1_norm = vectors_1 / jnp.linalg.norm(vectors_1, axis=-1, keepdims=True)
-    vec2_norm = vectors_2 / jnp.linalg.norm(vectors_2, axis=-1, keepdims=True)
-
     # Cosine similarity: (N1, N2)
-    V2_sim = jnp.dot(vec1_norm, vec2_norm.T)
+    V2_sim = jnp.dot(vectors_1, vectors_2.T)
 
     V2_sim = jax.lax.cond(
         allow_antiparallel,


### PR DESCRIPTION
Jax cosine similarity scoring for gaussian overlap now assumes that inputted vectors are already normalized. Previously, there were issues with nan gradients due to normalization of zero vectors for non-directional pharmacophores. This became a problem when vmap and jit were used.